### PR TITLE
DTM-1278 Fix level 1 and 2 Coverity issues in Openssl Sec API 2.3

### DIFF
--- a/src/sec_security_asn1kc.c
+++ b/src/sec_security_asn1kc.c
@@ -161,8 +161,8 @@ static Asn1KCAttribute_t *SecAsn1KC_AllocAttr(att_choice c)
                 Asn1KCAttribute_t_free(ptr);
                 return NULL;
             }
-            break;
             ptr->value->type = ASN1KCATTRIBUTE_T_CHOICE_BITSTRING;
+            break;
         case asn1_octet_string:
             ptr->value->c.octetstring = ASN1_OCTET_STRING_new();
             if(ptr->value->c.octetstring == NULL)
@@ -737,6 +737,11 @@ Sec_Result SecAsn1KC_Encode(Sec_Asn1KC *kc, SEC_BYTE *buf, SEC_SIZE buf_len, SEC
     {
         *written = der_len;
     }
+    else if (der_len < 0)
+    {
+        SEC_LOG_ERROR("der_encode_to_buffer failed");
+        return SEC_RESULT_FAILURE;
+    }
     else if (der_len > buf_len)
     {
         SEC_LOG_ERROR("der_encode_to_buffer invalide buffer length, der_len = %d, buf_len = %d", der_len, buf_len);
@@ -747,12 +752,6 @@ Sec_Result SecAsn1KC_Encode(Sec_Asn1KC *kc, SEC_BYTE *buf, SEC_SIZE buf_len, SEC
       *written = i2d_Sec_Asn1KC(kc, &buf);
     }
 
-    if (*written < 0)
-    {
-        SEC_LOG_ERROR("der_encode_to_buffer failed");
-        return SEC_RESULT_FAILURE;
-    }
-
     return SEC_RESULT_SUCCESS;
 }
 
@@ -761,11 +760,20 @@ Sec_Asn1KC *SecAsn1KC_Decode(SEC_BYTE *buf, SEC_SIZE buf_len)
     const unsigned char *c_buf = buf;
     Sec_Asn1KC *ret = NULL;
 
-    if (buf_len > LONG_MAX)
+    if (UINT32_MAX > LONG_MAX)
     {
-        SEC_LOG_ERROR("buf length rollover");
+        if (buf_len > LONG_MAX)
+        {
+             SEC_LOG_ERROR("buf length rollover");
+             return NULL;
+        }
+    }
+    else if (buf_len > UINT32_MAX)
+    {
+        SEC_LOG_ERROR("der_encode_to_buffer failed");
         return NULL;
     }
+
     ret = d2i_Sec_Asn1KC(NULL, &c_buf, (long)buf_len);
     return ret;
 }

--- a/src/sec_security_asn1kc.c
+++ b/src/sec_security_asn1kc.c
@@ -768,11 +768,6 @@ Sec_Asn1KC *SecAsn1KC_Decode(SEC_BYTE *buf, SEC_SIZE buf_len)
              return NULL;
         }
     }
-    else if (buf_len > UINT32_MAX)
-    {
-        SEC_LOG_ERROR("der_encode_to_buffer failed");
-        return NULL;
-    }
 
     ret = d2i_Sec_Asn1KC(NULL, &c_buf, (long)buf_len);
     return ret;

--- a/src/sec_security_common.c
+++ b/src/sec_security_common.c
@@ -1488,6 +1488,7 @@ Sec_Result SecDigest_SingleInput(Sec_ProcessorHandle *proc,
 	if (res != SEC_RESULT_SUCCESS)
 	{
 		SEC_LOG_ERROR("SecDigest_GetInstance failed");
+		SecDigest_Release(digest_handle, digest, digest_len);
 		return res;
 	}
 

--- a/src/sec_security_common.c
+++ b/src/sec_security_common.c
@@ -1488,7 +1488,11 @@ Sec_Result SecDigest_SingleInput(Sec_ProcessorHandle *proc,
 	if (res != SEC_RESULT_SUCCESS)
 	{
 		SEC_LOG_ERROR("SecDigest_GetInstance failed");
-		SecDigest_Release(digest_handle, digest, digest_len);
+    if(digest_handle != NULL)
+    {
+      SecDigest_Release(digest_handle, digest, digest_len);
+      digest_handle = NULL;
+    }
 		return res;
 	}
 

--- a/src/sec_security_json_yajl.c
+++ b/src/sec_security_json_yajl.c
@@ -1135,6 +1135,8 @@ Sec_Result SecJson_GenClose(Sec_JsonGenCtx *ctx, char *result, SEC_SIZE max_len)
 
     if (result != NULL && max_len > 0)
         result[0] = '\0';
+    else if(result == NULL)
+        goto cleanup;
 
     JSON_ENSURE_INIT();
 

--- a/src/sec_security_openssl.c
+++ b/src/sec_security_openssl.c
@@ -4937,8 +4937,10 @@ Sec_Result SecKey_ComputeBaseKeyDigest(Sec_ProcessorHandle* secProcHandle, SEC_B
                     &base_key))
     {
         SEC_LOG_ERROR("SecKey_GetInstance failed");
-        SecKey_Release(base_key);
-        base_key = NULL;
+        if(base_key != NULL) {
+          SecKey_Release(base_key);
+          base_key = NULL;
+        }
         return SEC_RESULT_FAILURE;
     }
 

--- a/src/sec_security_openssl.c
+++ b/src/sec_security_openssl.c
@@ -4515,6 +4515,13 @@ static Sec_Result _ConcatKDF(Sec_ProcessorHandle* secProcHandle,
     Sec_Result res = SEC_RESULT_FAILURE;
 
     digest_length = SecDigest_GetDigestLenForAlgorithm(digestAlgorithm);
+
+    if(digest_length == 0)
+    {
+        SEC_LOG_ERROR("Invalid digest length");
+        goto done;
+    }
+
     r = out_key_length / digest_length + ((out_key_length % digest_length == 0) ? 0 : 1);
 
     for (i = 1; i <= r; ++i)
@@ -4930,6 +4937,8 @@ Sec_Result SecKey_ComputeBaseKeyDigest(Sec_ProcessorHandle* secProcHandle, SEC_B
                     &base_key))
     {
         SEC_LOG_ERROR("SecKey_GetInstance failed");
+        SecKey_Release(base_key);
+        base_key = NULL;
         return SEC_RESULT_FAILURE;
     }
 
@@ -4938,6 +4947,8 @@ Sec_Result SecKey_ComputeBaseKeyDigest(Sec_ProcessorHandle* secProcHandle, SEC_B
     if (SEC_RESULT_SUCCESS != _Sec_SymetricFromKeyHandle(base_key, base_key_clear, sizeof(base_key_clear), &wr))
     {
         SEC_LOG_ERROR("_Sec_SymetricFromKeyHandle failed");
+        SecKey_Release(base_key);
+        base_key = NULL;
         return SEC_RESULT_FAILURE;
     }
     SecKey_Release(base_key);
@@ -5680,6 +5691,7 @@ Sec_Result SecProcessor_GetInfo(Sec_ProcessorHandle* secProcHandle,
 
     Sec_Memset(secProcInfo, 0x00, sizeof(Sec_ProcessorInfo));
     strncpy((char *)secProcInfo->version, SEC_API_VERSION, strlen(SEC_API_VERSION));
+    secProcInfo->version[strlen(SEC_API_VERSION)] = '\0';
 
     return SEC_RESULT_SUCCESS;
 }

--- a/src/sec_security_utils.c
+++ b/src/sec_security_utils.c
@@ -111,6 +111,7 @@ Sec_Result SecUtils_ReadFile(const char *path, void *data, SEC_SIZE data_len,
     FILE *f = NULL;
     Sec_Result sec_res = SEC_RESULT_SUCCESS;
     SEC_BYTE last_byte;
+    SEC_SIZE read = 0;
 
     *data_read = 0;
 
@@ -134,7 +135,7 @@ Sec_Result SecUtils_ReadFile(const char *path, void *data, SEC_SIZE data_len,
         goto cleanup;
     }
 
-    fread(&last_byte, 1, 1, f);
+    read= fread(&last_byte, 1, 1, f);
 
     if (0 == feof(f))
     {
@@ -374,7 +375,8 @@ Sec_Result SecUtils_RmFile(const char *path)
 	if (len > 0) {
 		zeros = calloc(len, 1);
 		if (zeros != NULL) {
-			SecUtils_WriteFile(path, zeros, len);
+			if (SecUtils_WriteFile(path, zeros, len) != SEC_RESULT_SUCCESS)
+				SEC_LOG_ERROR("Could not write zeros");
 			free(zeros);
 		} else {
 	        SEC_LOG_ERROR("calloc failed");


### PR DESCRIPTION
Reason for change: Squashed the following code commits:i
DTM-1283 terminate buffer with null
DTM-1284 potential resource leak
DTM-1285 potential resource leak;
DTM-1286 fix unreachable code structure
DTM-1287 prevent null deref
DTM-1288 check return from SecUtils_WriteFile
DTM-1289 prevent div by 0
DTM-1290 Check fread return
DTM-1291 fix unsigned underflow check
DTM-1292 Fix rollover check for 64 bit builds

Test Procedure: Run Openssl Unit tests and run coverity scan

Risks: Low

Signed-off-by: Joseph <Joseph_Hewitt@cable.comcast.com>